### PR TITLE
Special events poprawki

### DIFF
--- a/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/controller/ScheduleController.java
+++ b/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/controller/ScheduleController.java
@@ -404,4 +404,14 @@ public class ScheduleController {
         scheduleService.copySpecialEventDaySchedules(sourceDate, targetDate, roleName, sectionId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/special-event/{eventId}/copy-from-normal-week")
+    public ResponseEntity<Void> copyFromNormalWeek(
+            @PathVariable Long eventId,
+            @RequestParam @DateTimeFormat(pattern = "dd-MM-yyyy") LocalDate date,
+            @RequestParam String roleName) {
+
+        scheduleService.copyFromNormalWeekToSpecialEvent(date, roleName);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/controller/ScheduleController.java
+++ b/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/controller/ScheduleController.java
@@ -414,4 +414,15 @@ public class ScheduleController {
         scheduleService.copyFromNormalWeekToSpecialEvent(date, roleName);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/special-event/daily")
+    public ResponseEntity<Void> deleteSpecialEventSchedule(
+            @RequestParam Long userId,
+            @RequestParam Long taskId,
+            @RequestParam @DateTimeFormat(pattern = "dd-MM-yyyy") LocalDate date,
+            @RequestParam(required = false) Long sectionId) {
+
+        scheduleService.deleteSpecialEventSchedule(userId, taskId, date, sectionId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
+++ b/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
@@ -181,9 +181,7 @@ public class ScheduleService {
     }
 
     public List<Schedule> getAllSchedulesForUserInSpecifiedWeek(Long userId, LocalDate from, LocalDate to) {
-        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to).stream()
-                .filter(s -> s.getTaskSection() == null)
-                .collect(Collectors.toList());
+        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to);
     }
 
     public List<Task> getAvailableTasksBySupervisorRole(String supervisor, LocalDate from, LocalDate to) {
@@ -1893,6 +1891,23 @@ public class ScheduleService {
                         newSchedule.setTaskSection(section);
                         scheduleRepository.save(newSchedule);
                     }
+                }
+            }
+        }
+    }
+
+    @Transactional
+    public void deleteSpecialEventSchedule(Long userId, Long taskId, LocalDate date, Long sectionId) {
+        // Używamy bezpiecznej metody, która nie ma nałożonych żadnych filtrów
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndDateOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, date);
+
+        for (Schedule schedule : schedules) {
+            if (schedule.getTask().getId().equals(taskId)) {
+                Long existingSectionId = schedule.getTaskSection() != null ? schedule.getTaskSection().getId() : null;
+
+                // Jeśli zgadza się ID zadania oraz ID sekcji, usuwamy z bazy
+                if (Objects.equals(existingSectionId, sectionId)) {
+                    scheduleRepository.deleteById(schedule.getId());
                 }
             }
         }

--- a/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
+++ b/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
@@ -1447,7 +1447,12 @@ public class ScheduleService {
         // 3. --- BATCH FETCHING (Pobieranie hurtowe) ---
 
         // A. Grafiki na ten tydzień dla wszystkich userów
-        List<Schedule> allSchedulesThisWeek = scheduleRepository.findByUserIdInAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userIds, weekStart, weekEnd);
+        List<Schedule> allSchedulesThisWeekRaw = scheduleRepository.findByUserIdInAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userIds, weekStart, weekEnd);
+
+        // --- ZMIANA: Całkowicie ignorujemy wpisy z nullem (z normalnego tygodnia / całodniowe) ---
+        List<Schedule> allSchedulesThisWeek = allSchedulesThisWeekRaw.stream()
+                .filter(s -> s.getTaskSection() != null)
+                .collect(Collectors.toList());
 
         // B. Przeszkody na dzisiaj
         List<Obstacle> allObstaclesToday = obstacleRepository.findActiveObstaclesForUsersOnDate(userIds, date);

--- a/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
+++ b/backend/dominicanAppBackend/src/main/java/org/verduttio/dominicanappbackend/service/schedule/ScheduleService.java
@@ -181,7 +181,9 @@ public class ScheduleService {
     }
 
     public List<Schedule> getAllSchedulesForUserInSpecifiedWeek(Long userId, LocalDate from, LocalDate to) {
-        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to);
+        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to).stream()
+                .filter(s -> s.getTaskSection() == null)
+                .collect(Collectors.toList());
     }
 
     public List<Task> getAvailableTasksBySupervisorRole(String supervisor, LocalDate from, LocalDate to) {
@@ -324,7 +326,10 @@ public class ScheduleService {
     }
 
     public List<Schedule> getSchedulesByUserIdAndDateBetween(Long userId, LocalDate from, LocalDate to) {
-        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to);
+        return scheduleRepository.findByUserIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(userId, from, to)
+                .stream()
+                .filter(s -> s.getTaskSection() == null) // TYLKO ZWYKŁY TYDZIEŃ
+                .collect(Collectors.toList());
     }
 
     private List<Task> getTasksFromSchedules(List<Schedule> schedules) {
@@ -429,7 +434,10 @@ public class ScheduleService {
     }
 
     public boolean isScheduleInConflictWithOtherSchedules(Schedule schedule) {
-        List<Schedule> schedules = scheduleRepository.findByUserIdAndDateOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(schedule.getUser().getId(), schedule.getDate());
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndDateOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(schedule.getUser().getId(), schedule.getDate())
+                .stream()
+                .filter(s -> s.getTaskSection() == null) // IGNORUJEMY WYDARZENIA SPECJALNE W KONFLIKTACH
+                .toList();
         for(Schedule otherSchedule : schedules) {
             boolean isFeastDate = specialDateRepository.existsByTypeAndDate(SpecialDateType.FEAST, otherSchedule.getDate());
             if(conflictService.tasksAreInConflict(schedule.getTask().getId(), otherSchedule.getTask().getId(), otherSchedule.getDate().getDayOfWeek(), isFeastDate)) {
@@ -697,7 +705,10 @@ public class ScheduleService {
             throw new EntityNotFoundException("Task with given id does not exist");
         }
 
-        return scheduleRepository.findByTaskIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(taskId, from, to);
+        return scheduleRepository.findByTaskIdAndDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(taskId, from, to)
+                .stream()
+                .filter(s -> s.getTaskSection() == null) // TYLKO ZWYKŁY TYDZIEŃ
+                .collect(Collectors.toList());
     }
 
     public List<ScheduleShortInfoForTask> getScheduleShortInfoForEachTaskForSpecifiedWeek(LocalDate from, LocalDate to) {
@@ -973,7 +984,10 @@ public class ScheduleService {
         List<Task> tasksByRole = taskService.findTasksBySupervisorRoleName(roleName);
         List<User> usersWhichCanPerformTasks = getUsersEligibleForTasks(tasksByRole, false);
         boolean weekWithFeast = !specialDateRepository.findByTypeAndDateBetween(SpecialDateType.FEAST, from, to).isEmpty();
-        List<Schedule> schedulesForThisWeek = scheduleRepository.findByDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(from, to);
+        List<Schedule> schedulesForThisWeek = scheduleRepository.findByDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(from, to)
+                .stream()
+                .filter(s -> s.getTaskSection() == null)
+                .collect(Collectors.toList());
         List<Conflict> allConflicts = conflictService.getAllConflicts();
 
         return usersWhichCanPerformTasks.stream()
@@ -988,7 +1002,10 @@ public class ScheduleService {
         User user = userService.getUserById(userId).orElseThrow(() ->
                 new EntityNotFoundException("User with given id does not exist"));
         boolean weekWithFeast = specialDateRepository.existsByTypeAndDateBetween(SpecialDateType.FEAST, from, to);
-        List<Schedule> schedulesForThisWeek = scheduleRepository.findByDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(from, to);
+        List<Schedule> schedulesForThisWeek = scheduleRepository.findByDateBetweenOrderByTask_SupervisorRole_SortOrderAscTask_SortOrderAsc(from, to)
+                .stream()
+                .filter(s -> s.getTaskSection() == null)
+                .collect(Collectors.toList());
         List<Conflict> allConflicts = conflictService.getAllConflicts();
 
         return createUserTasksScheduleInfoWeekly(user, tasksByRole, from, to, weekWithFeast, schedulesForThisWeek, allConflicts);
@@ -1822,6 +1839,61 @@ public class ScheduleService {
                 // (Usunięto setWeekStartDate i setWeekEndDate, ponieważ encja Schedule tego nie przechowuje)
 
                 scheduleRepository.save(newSchedule);
+            }
+        }
+    }
+
+    @Transactional
+    public void copyFromNormalWeekToSpecialEvent(LocalDate date, String roleName) {
+        // 1. Pobieramy grafiki z normalnego tygodnia dla wybranego dnia (te, które mają taskSection == null)
+        List<Schedule> normalSchedules = getAllSchedulesByFromAndToDates(date, date).stream()
+                .filter(s -> s.getTask() != null && s.getTask().getSupervisorRole() != null)
+                .filter(s -> s.getTask().getSupervisorRole().getName().equals(roleName))
+                .filter(s -> s.getTaskSection() == null) // Interesują nas TYLKO wpisy całodniowe z bazy
+                .toList();
+
+        // 2. Pobieramy wszystkie grafiki z tego dnia, żeby sprawdzić, czy już czegoś nie wyznaczyliśmy i uniknąć duplikatów
+        List<Schedule> targetSchedules = getAllSchedulesByFromAndToDates(date, date);
+
+        for (Schedule src : normalSchedules) {
+            Task task = src.getTask();
+            User user = src.getUser();
+            Set<TaskSection> sectionsToAssign = task.getTaskSections();
+
+            // Jeśli zadanie nie ma przypisanych żadnych pór dnia (jest traktowane globalnie)
+            if (sectionsToAssign == null || sectionsToAssign.isEmpty()) {
+                boolean alreadyExists = targetSchedules.stream().anyMatch(t ->
+                        t.getUser().getId().equals(user.getId()) &&
+                                t.getTask().getId().equals(task.getId()) &&
+                                t.getTaskSection() == null
+                );
+
+                if (!alreadyExists) {
+                    Schedule newSchedule = new Schedule();
+                    newSchedule.setUser(user);
+                    newSchedule.setTask(task);
+                    newSchedule.setDate(date);
+                    newSchedule.setTaskSection(null);
+                    scheduleRepository.save(newSchedule);
+                }
+            } else {
+                // Jeśli zadanie MA pory dnia, przypisujemy brata do KAŻDEJ z nich
+                for (org.verduttio.dominicanappbackend.domain.TaskSection section : sectionsToAssign) {
+                    boolean alreadyExists = targetSchedules.stream().anyMatch(t ->
+                            t.getUser().getId().equals(user.getId()) &&
+                                    t.getTask().getId().equals(task.getId()) &&
+                                    t.getTaskSection() != null && t.getTaskSection().getId().equals(section.getId())
+                    );
+
+                    if (!alreadyExists) {
+                        Schedule newSchedule = new Schedule();
+                        newSchedule.setUser(user);
+                        newSchedule.setTask(task);
+                        newSchedule.setDate(date);
+                        newSchedule.setTaskSection(section);
+                        scheduleRepository.save(newSchedule);
+                    }
+                }
             }
         }
     }

--- a/frontend/dominicanappfrontend/src/models/Interfaces.ts
+++ b/frontend/dominicanappfrontend/src/models/Interfaces.ts
@@ -65,6 +65,7 @@ interface Schedule {
     task: Task;
     user: User;
     date: string;
+    taskSection?: TaskSection | null;
 }
 
 interface SpecialDate {

--- a/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
+++ b/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
@@ -553,18 +553,6 @@ function AddScheduleSpecialEvent() {
                     });
                 });
 
-                // Zawsze dobijamy wpis z nullem ("Cały dzień"), żeby wyczyścić śmieci i zablokowane stany z przeszłości
-                const reqDataNull = { userId, taskId, taskDate: taskDateStr, weekStartDate: weekStartStr, weekEndDate: weekEndStr, taskSectionId: null };
-                promises.push(fetch(`${backendUrl}/api/schedules/forDailyPeriod`, {
-                    method: 'DELETE',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {})
-                    },
-                    credentials: 'include',
-                    body: JSON.stringify(reqDataNull)
-                }));
-
                 await Promise.all(promises);
                 fetchSchedule();
             } catch (err) {

--- a/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
+++ b/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
@@ -35,7 +35,8 @@ import {
     faExpand,
     faCompress,
     faTable,
-    faFileLines
+    faFileLines,
+    faClone
     } from '@fortawesome/free-solid-svg-icons';
 import UserShortScheduleHistoryPopup from "../common/UserShortScheduleHistoryPopup";
 import {isTaskFullyAssigned, countAssignedUsers} from "./ScheduleUtils";
@@ -375,6 +376,36 @@ function AddScheduleSpecialEvent() {
         } catch (error) {
             console.error("Błąd podczas kopiowania dnia", error);
             alert("Wystąpił problem podczas kopiowania.");
+        } finally {
+            setCopyLoading(false);
+        }
+    };
+
+    // --- LOGIKA POBIERANIA ZE ZWYKŁEGO TYGODNIA ---
+    const handleCopyFromNormalWeek = async () => {
+        if (!window.confirm(`Czy na pewno chcesz pobrać zwykłe oficja z dnia ${format(currentDate, 'dd.MM')} i rozdzielić je na pory dnia dla Wydarzenia Specjalnego?`)) return;
+
+        setCopyLoading(true);
+        const dateStr = dateFormatter.formatDate(format(currentDate, 'dd-MM-yyyy'));
+        const url = `${backendUrl}/api/schedules/special-event/${eventId}/copy-from-normal-week?date=${dateStr}&roleName=${roleName}`;
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {})
+                },
+                credentials: 'include'
+            });
+
+            if (!response.ok) throw new Error("Błąd z serwera podczas kopiowania");
+
+            fetchSchedule();
+            alert("Pobrano oficja ze zwykłego tygodnia!");
+
+        } catch (error) {
+            console.error("Błąd podczas pobierania oficjów ze zwykłego tygodnia", error);
+            alert("Wystąpił problem podczas pobierania oficjów.");
         } finally {
             setCopyLoading(false);
         }
@@ -972,10 +1003,25 @@ function AddScheduleSpecialEvent() {
 
                 {/* --- KOPIOWANIE DNIA --- */}
                 {event && (
-                    <div className="d-flex flex-column align-items-center mb-3">
-                        <h3 className="fw-bold entity-header-dynamic-size mb-4 mx-4">
-                            Skopiuj dzisiejsze oficja na:
-                        </h3>
+                    <div className="d-flex flex-column align-items-center mb-5 mt-4">
+                        <h5 className="fw-bold text-muted mb-3 mx-4">
+                            Zarządzanie dniami:
+                        </h5>
+
+                        {/* Nowy przycisk: Kopiowanie ze zwykłego tygodnia */}
+                        <div className="mb-4">
+                            <button
+                                className="btn btn-primary text-white shadow-sm fw-bold px-4 py-2"
+                                onClick={handleCopyFromNormalWeek}
+                                disabled={copyLoading}
+                            >
+                                <FontAwesomeIcon icon={faClone} className="me-2"/>
+                                Pobierz oficja ze zwykłego grafiku na dzisiaj
+                            </button>
+                        </div>
+
+                        <h6 className="text-muted fw-bold mb-3">Skopiuj widoczne przypisania z dzisiaj na:</h6>
+
                         <div className="d-flex justify-content-center flex-wrap gap-2">
                             {eachDayOfInterval({ start: parseISO(event.startDate), end: parseISO(event.endDate) }).map(day => {
                                 const isCurrent = format(day, 'yyyy-MM-dd') === format(currentDate, 'yyyy-MM-dd');
@@ -993,7 +1039,7 @@ function AddScheduleSpecialEvent() {
                                 );
                             })}
                         </div>
-                        {copyLoading && <div className="mt-3 text-primary fw-bold">Trwa kopiowanie oficjów, to może potrwać kilka sekund... <LoadingSpinner/></div>}
+                        {copyLoading && <div className="mt-3 text-primary fw-bold">Trwa operacja, to może potrwać kilka sekund... <LoadingSpinner/></div>}
                     </div>
                 )}
 

--- a/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
+++ b/frontend/dominicanappfrontend/src/pages/schedule/pages/AddScheduleSpecialEvent.tsx
@@ -562,37 +562,58 @@ function AddScheduleSpecialEvent() {
 
     async function unassignTask(userId: number, taskId: number) {
         const taskDateStr = dateFormatter.formatDate(format(currentDate, 'dd-MM-yyyy'));
-        const weekStartStr = dateFormatter.formatDate(format(startOfWeek(currentDate, {weekStartsOn: 0}), 'dd-MM-yyyy'));
-        const weekEndStr = dateFormatter.formatDate(format(endOfWeek(currentDate, {weekStartsOn: 0}), 'dd-MM-yyyy'));
-
         const task = visibleTasks.find(t => t.id === taskId);
         const specificSections = task?.taskSections || [];
 
-        // Jeśli zadanie MA zdefiniowane pory, czyścimy wszystkie możliwe warianty dla tego dnia
-        if (specificSections.length > 0) {
-            try {
-                const promises = specificSections.map(sec => {
-                    const reqData = { userId, taskId, taskDate: taskDateStr, weekStartDate: weekStartStr, weekEndDate: weekEndStr, taskSectionId: sec.id };
-                    return fetch(`${backendUrl}/api/schedules/forDailyPeriod`, {
-                        method: 'DELETE',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {})
-                        },
-                        credentials: 'include',
-                        body: JSON.stringify(reqData)
-                    });
-                });
+        // Flaga: czy zadanie jest ściśle niestandardowe (przypisane do tego konkretnego eventu)
+        const isSpecialTask = task?.specialEventId !== null && task?.specialEventId !== undefined;
 
-                await Promise.all(promises);
-                fetchSchedule();
-            } catch (err) {
-                console.error("Błąd podczas usuwania z wielu sekcji", err);
+        try {
+            if (currentSectionId !== null) {
+                // 1. Użytkownik jest w KONKRETNEJ zakładce (np. Rano) - usuwamy tylko z tej pory!
+                const url = `${backendUrl}/api/schedules/special-event/daily?userId=${userId}&taskId=${taskId}&date=${taskDateStr}&sectionId=${currentSectionId}`;
+                await fetch(url, {
+                    method: 'DELETE',
+                    headers: { ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {}) },
+                    credentials: 'include'
+                });
+            } else {
+                // 2. Użytkownik jest w zakładce "Wszystkie"
+                if (specificSections.length > 0) {
+                    // Usuwamy ze wszystkich pór zadania
+                    const promises = specificSections.map(sec => {
+                        const url = `${backendUrl}/api/schedules/special-event/daily?userId=${userId}&taskId=${taskId}&date=${taskDateStr}&sectionId=${sec.id}`;
+                        return fetch(url, {
+                            method: 'DELETE',
+                            headers: { ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {}) },
+                            credentials: 'include'
+                        });
+                    });
+
+                    // NOWOŚĆ: Jeśli to task niestandardowy (z eventu), dla pewności czyścimy też wpis całodniowy (null)
+                    if (isSpecialTask) {
+                        const urlNull = `${backendUrl}/api/schedules/special-event/daily?userId=${userId}&taskId=${taskId}&date=${taskDateStr}`;
+                        promises.push(fetch(urlNull, {
+                            method: 'DELETE',
+                            headers: { ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {}) },
+                            credentials: 'include'
+                        }));
+                    }
+
+                    await Promise.all(promises);
+                } else {
+                    // Zadanie całkowicie bez pór (domyślnie "cały dzień" np. zwykłe dyżury przeniesione do eventu)
+                    const url = `${backendUrl}/api/schedules/special-event/daily?userId=${userId}&taskId=${taskId}&date=${taskDateStr}`;
+                    await fetch(url, {
+                        method: 'DELETE',
+                        headers: { ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {}) },
+                        credentials: 'include'
+                    });
+                }
             }
-        } else {
-            // Zadanie BEZ zdefiniowanych pór ("Cały dzień")
-            const reqData = { userId, taskId, taskDate: taskDateStr, weekStartDate: weekStartStr, weekEndDate: weekEndStr, taskSectionId: currentSectionId };
-            unassignRequest(reqData, () => fetchSchedule(), false, `${backendUrl}/api/schedules/forDailyPeriod`, 'DELETE');
+            fetchSchedule();
+        } catch (err) {
+            console.error("Błąd podczas usuwania", err);
         }
     }
 

--- a/frontend/dominicanappfrontend/src/pages/user/CurrentUserObstaclesTable.tsx
+++ b/frontend/dominicanappfrontend/src/pages/user/CurrentUserObstaclesTable.tsx
@@ -71,29 +71,27 @@ function CurrentUserObstaclesTable () {
                                 }
                             }
                             return (
-                                <>
-                                    <tr key={obstacle.id}
-                                        className={className}>
-                                        <td className='max-column-width-200'>{obstacle.tasks.map(task => task.nameAbbrev).join(", ")}</td>
-                                        <td>{format(obstacle.fromDate, "dd.MM.yyyy")}</td>
-                                        <td>{format(obstacle.toDate, "dd.MM.yyyy")}</td>
-                                        <td>
-                                    <span className={
-                                        obstacle.status === ObstacleStatus.AWAITING ? 'highlighted-text-awaiting' :
-                                            obstacle.status === ObstacleStatus.APPROVED ? 'highlighted-text-approved' :
-                                                obstacle.status === ObstacleStatus.REJECTED ? 'highlighted-text-rejected' : ''
-                                    }>
-                                        {obstacleStatusTranslation[obstacle.status]}
-                                    </span>
-                                        </td>
-                                        <td>
-                                            <button className="btn btn-dark" onClick={() => {
-                                                navigate(`/obstacles/my/${obstacle.id}`)
-                                            }}>Szczegóły
-                                            </button>
-                                        </td>
-                                    </tr>
-                                </>
+                                <tr key={obstacle.id}
+                                    className={className}>
+                                    <td className='max-column-width-200'>{obstacle.tasks.map(task => task.nameAbbrev).join(", ")}</td>
+                                    <td>{format(obstacle.fromDate, "dd.MM.yyyy")}</td>
+                                    <td>{format(obstacle.toDate, "dd.MM.yyyy")}</td>
+                                    <td>
+                                <span className={
+                                    obstacle.status === ObstacleStatus.AWAITING ? 'highlighted-text-awaiting' :
+                                        obstacle.status === ObstacleStatus.APPROVED ? 'highlighted-text-approved' :
+                                            obstacle.status === ObstacleStatus.REJECTED ? 'highlighted-text-rejected' : ''
+                                }>
+                                    {obstacleStatusTranslation[obstacle.status]}
+                                </span>
+                                    </td>
+                                    <td>
+                                        <button className="btn btn-dark" onClick={() => {
+                                            navigate(`/obstacles/my/${obstacle.id}`)
+                                        }}>Szczegóły
+                                        </button>
+                                    </td>
+                                </tr>
                             )
                         })}
                         </tbody>

--- a/frontend/dominicanappfrontend/src/pages/user/UserTasksStatistics.tsx
+++ b/frontend/dominicanappfrontend/src/pages/user/UserTasksStatistics.tsx
@@ -22,7 +22,6 @@ const UserTasksStatistics: React.FC<UserTasksStatisticsProps> = ({userId}) => {
     useEffect(() => {
         requestFetchUserStatisticsForTasks(null, (data: UserTaskStatistics[]) => {
             setUserStatisticsForTasks(data);
-            console.log(data)
         });
     }, [requestFetchUserStatisticsForTasks]);
 

--- a/frontend/dominicanappfrontend/src/pages/user/UserWeekSchedule.tsx
+++ b/frontend/dominicanappfrontend/src/pages/user/UserWeekSchedule.tsx
@@ -15,30 +15,40 @@ interface UserWeekScheduleProps {
 }
 
 const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek, setCurrentWeek}) => {
-    // const [currentWeek, setCurrentWeek] = useState(new Date());
-    const currentWeekRef = useRef(currentWeek); // useRef to keep the value of currentWeek in the closure of useEffect
+    const currentWeekRef = useRef(currentWeek);
     const from = format(startOfWeek(currentWeek, {weekStartsOn: 0}), 'dd-MM-yyyy');
     const to = format(endOfWeek(currentWeek, {weekStartsOn: 0}), 'dd-MM-yyyy');
+
     const [userSchedules, setUserSchedules] = useState<Schedule[]>([]);
+    const [specialEvents, setSpecialEvents] = useState<any[]>([]); // Zapisujemy listę wydarzeń z bazy
+
+    // Hook dla grafików
     const {
         request: fetchSchedule,
         error,
         loading
     } = useHttp(`${backendUrl}/api/schedules/users/${userId}/week?from=${from}&to=${to}`, 'GET');
+
+    // Hook dla wydarzeń specjalnych
+    const { request: fetchEvents } = useHttp(`${backendUrl}/api/special-events`, 'GET');
+
     const todayDate = new Date();
     const [screenWidth, setScreenWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         const handleResize = () => setScreenWidth(window.innerWidth);
         window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
-        return () => {
-            window.removeEventListener('resize', handleResize);
-        };
+    // Pobieramy wydarzenia na samym początku
+    useEffect(() => {
+        fetchEvents(null, (data) => setSpecialEvents(data || []));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
-        currentWeekRef.current = currentWeek; // keep the value of currentWeek up to date
+        currentWeekRef.current = currentWeek;
 
         fetchSchedule(null, (data) => {
             if (format(startOfWeek(currentWeekRef.current, {weekStartsOn: 0}), 'dd-MM-yyyy') === from &&
@@ -53,14 +63,54 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
         return Array.from({length: 7}).map((_, i) => addDays(weekStart, i));
     }, [currentWeek]);
 
+    // Funkcja sprawdzająca czy dzień fizycznie zawiera się w jakimkolwiek Wydarzeniu
+    const isDayInSpecialEvent = (day: Date) => {
+        const formatted = format(day, 'yyyy-MM-dd');
+        return specialEvents.some(event => formatted >= event.startDate && formatted <= event.endDate);
+    };
+
     const tasksForDay = (day: Date) => {
         const formattedDay = format(day, 'yyyy-MM-dd');
-        const dailyTasks = userSchedules.filter(schedule => schedule.date === formattedDay);
-        const dailyTaskNamesAbbrevs = dailyTasks.map(schedule => schedule.task.nameAbbrev);
+        let dailyTasks = userSchedules.filter(schedule => schedule.date === formattedDay);
+
+        if (isDayInSpecialEvent(day)) {
+            // Jeśli to czas SE - bierzemy TYLKO taski specjalne i CAŁKOWICIE ignorujemy normalne
+            const specialTasks = dailyTasks.filter(schedule =>
+                schedule.taskSection != null ||
+                schedule.task.specialEvent != null ||
+                schedule.task.specialEventId != null
+            );
+
+            specialTasks.sort((a, b) => {
+                const idA = a.taskSection?.id || 0;
+                const idB = b.taskSection?.id || 0;
+                return idA - idB;
+            });
+
+            return (
+                <div key={formattedDay} className="d-flex flex-column gap-2">
+                    {specialTasks.map((schedule, index) => (
+                        <div key={index} className="lh-sm">
+                            <span className="fw-bold">{schedule.task.nameAbbrev}</span>{' '}
+                            {schedule.taskSection && (
+                                <small>({schedule.taskSection.name})</small>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            );
+        }
+
+        // Jeśli to ZWYKŁY dzień (poza SE) - bierzemy TYLKO normalne wpisy
+        const normalTasks = dailyTasks.filter(schedule =>
+             schedule.taskSection == null && schedule.task.specialEvent == null && schedule.task.specialEventId == null
+        );
+
+        const normalTasksAbbrevs = normalTasks.map(schedule => schedule.task.nameAbbrev);
 
         return (
             <div key={formattedDay}>
-                {dailyTaskNamesAbbrevs.map((taskNameAbbrev, index) => (
+                {normalTasksAbbrevs.map((taskNameAbbrev, index) => (
                     <div key={index}>{taskNameAbbrev}</div>
                 ))}
             </div>
@@ -76,7 +126,7 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
         return (
             <div className="d-flex-no-media-resize justify-content-center">
                 <div className="table-responsive-fit-content">
-                    <table className="table table-hover table-striped table-rounded table-shadow table-bordered text-cente mb-0">
+                    <table className="table table-hover table-striped table-rounded table-shadow table-bordered text-center mb-0">
                         <thead className="table-dark">
                         <tr>
                             {weekDays.map((day, index) => {
@@ -97,7 +147,7 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
                         <tbody>
                         <tr>
                             {weekDays.map((day, index) => (
-                                <td className="column-width-150" key={index}>{tasksForDay(day)}</td>
+                                <td className="column-width-150 align-middle" key={index}>{tasksForDay(day)}</td>
                             ))}
                         </tr>
                         </tbody>
@@ -118,10 +168,10 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
                             const polishAbbreviation = daysOfWeekAbbreviation[englishDayOfWeek];
                             return (
                                 <tr key={index}>
-                                    <th className={format(day, 'dd.MM.yyyy') === format(todayDate, 'dd.MM.yyyy') ? 'table-success' : 'table-dark'}>
+                                    <th className={format(day, 'dd.MM.yyyy') === format(todayDate, 'dd.MM.yyyy') ? 'table-success align-middle text-center' : 'table-dark align-middle text-center'} style={{width: '30%'}}>
                                         {polishAbbreviation} <br/> {format(day, 'dd.MM.yyyy')}
                                     </th>
-                                    <td>{tasksForDay(day)}</td>
+                                    <td className="align-middle">{tasksForDay(day)}</td>
                                 </tr>
                             );
                         })}
@@ -132,7 +182,6 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
 
         )
     }
-
 
     const renderContent = () => {
         if (loading) return <LoadingSpinner/>;
@@ -150,6 +199,5 @@ const UserWeekSchedule: React.FC<UserWeekScheduleProps> = ({userId, currentWeek,
         </div>
     );
 }
-
 
 export default UserWeekSchedule;


### PR DESCRIPTION
## 📝 Opis zmian

Ten Pull Request wprowadza pełną separację logiki Wydarzeń Specjalnych (Special Events) od standardowego systemu wyznaczania oficjów. Dzięki temu zapobiegamy przenikaniu się grafików, sztucznym konfliktom i niechcianemu nadpisywaniu danych. Dodatkowo PR poprawia wyświetlanie grafików na stronie głównej w trakcie trwania wydarzeń oraz czyści aplikację z drobnych błędów frontendowych.

## 🚀 Główne zmiany (Features & Refactor)

* **Rozdzielenie logiki Special Events i normalnego grafiku:** 
  * Standardowy system wyznaczania (oraz weryfikacja konfliktów) całkowicie ignoruje teraz wpisy posiadające przypisaną porę dnia (`taskSection != null`).
  * Wydarzenia Specjalne zyskały niezależne, dedykowane endpointy m.in. do usuwania oficjów (np. `DELETE /api/schedules/special-event/daily`), dzięki czemu operacje w jednym module nie psują drugiego.
* **Nowe opcje kopiowania dla Special Events:**
  * Dodano możliwość skopiowania całego widocznego dnia na inny dzień.
  * Dodano funkcję "Pobierz ze zwykłego tygodnia", która automatycznie zaciąga standardowe, całodniowe przypisania i rozbija je na pory dnia wymagane przez wydarzenie.
* **Poprawa wyświetlania na stronie głównej (`UserWeekSchedule`):** 
  * Komponent poprawnie weryfikuje, czy dany dzień wypada w trakcie Wydarzenia Specjalnego. 
  * Jeśli tak – całkowicie ukrywa "nudne" oficja z normalnego grafiku, a wyświetla wyłącznie te specjalne, dodając w nawiasach porę dnia (np. `(Rano)`).
  * Oficja specjalne są teraz poprawnie sortowane chronologicznie według ID pory dnia.

## 🐛 Poprawki (Bugfixes)

* **Usunięcie błędu z usuwaniem zadań specjalnych:** Kliknięcie usunięcia zadania niestandardowego w zakładce "Wszystkie" poprawnie usuwa teraz wszystkie powiązane sekcje oraz ukryte wpisy całodniowe (z `null`), gwarantując pełne wyczyszczenie dnia.
* **Oczyszczenie konsoli z warningów:** 
  * Naprawiono błąd `Warning: Each child in a list should have a unique "key" prop` w komponencie `CurrentUserObstaclesTable` (usunięto niepotrzebny React Fragment blokujący przekazanie klucza do wiersza tabeli).
  * Usunięto zapomniane wywołania `console.log` w `UserTasksStatistics.tsx`.